### PR TITLE
Fix SEGV in Ruby 2.4

### DIFF
--- a/ext/extreme_timeout/extreme_timeout.c
+++ b/ext/extreme_timeout/extreme_timeout.c
@@ -82,6 +82,10 @@ timeout_cb(VALUE block)
     return rb_funcall(block, rb_intern("call"), 0);
 }
 
+/*
+ * NOTE: Exposing this function name "timeout" caused segmentation
+ * fault in some environment (See PR #6).
+ */
 static VALUE
 timeout(int argc, VALUE *argv, VALUE self)
 {

--- a/ext/extreme_timeout/extreme_timeout.c
+++ b/ext/extreme_timeout/extreme_timeout.c
@@ -82,7 +82,7 @@ timeout_cb(VALUE block)
     return rb_funcall(block, rb_intern("call"), 0);
 }
 
-VALUE
+static VALUE
 timeout(int argc, VALUE *argv, VALUE self)
 {
     int exitcode = 1, state;


### PR DESCRIPTION
It seems that extreme_timeout does not behave correctly (raises Segmetation Faults) in ruby 2.4 on Ubuntu platform. This PR should fix such issue.

I added a Dockerfile (`Dockerfile.ruby-2.4`) in this PR to test. You can run spec like the following.

```
$ docker build -f Dockerfile.ruby-2.4 .
...
Removing intermediate container 123456abcdef
Successfully built 111111aaaaaa
$ docker run 111111aaaaaa
Run options: include {:focus=>true}
...
Finished in 8.04 seconds (files took 0.06717 seconds to load)
10 examples, 0 failures

Randomized with seed 52811
```